### PR TITLE
add lifecycle badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/inbo/vespawatchr/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/inbo/vespawatchr/actions/workflows/R-CMD-check.yaml)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
 The goal of vespawatchr is to ...


### PR DESCRIPTION
Adding a lifecycle badge to the readme to indicate that the package is currently in an experimental state. You can update this badge with `usethis::use_lifecycle_badge()`