### PR TITLE
31 Adding metadata retrieval to `get_record()`

### DIFF
--- a/R/get_fields.R
+++ b/R/get_fields.R
@@ -8,7 +8,8 @@
 #' @export
 #'
 #' @examples \dontrun{get_fields("Vespa-Watch")}
-get_fields <- function(name = "Vespa-Watch", access_token = get_access_token(quiet = TRUE)) {
+get_fields <- function(name = "Vespa-Watch",
+                       access_token = get_access_token(quiet = TRUE)) {
   # check input params
   assertthat::assert_that(assertthat::is.string(access_token))
   assertthat::assert_that(assertthat::is.string(name))

--- a/R/get_records.R
+++ b/R/get_records.R
@@ -46,7 +46,7 @@ get_records <- function(inspection_name = "Vespa-Watch",
     ## convert into tibble
     purrr::chuck("returndata") %>%
     # based on get_metadata
-    {
+    (function (.){
       if (get_metadata == "id") {
         # get the data with the id
         purrr::map(., ~ base::append(
@@ -60,7 +60,7 @@ get_records <- function(inspection_name = "Vespa-Watch",
         # or get the data object for every element
         purrr::map(., ~ purrr::chuck(.x, "data"))
       }
-    } %>%
+    }) %>%
     # flatten list contained in data
     purrr::map(~ purrr::list_flatten(.x)) %>%
     # create a table per record

--- a/R/get_records.R
+++ b/R/get_records.R
@@ -3,9 +3,8 @@
 #' @param inspection_name name of the custom inspection to return records for
 #' @param access_token access token from `get_access_token()`
 #' @param get_metadata Indicates whether to include metadata in the returned
-#'  data. Possible values are "id" (only include observation `insp_order`),
-#'  "none" (exclude all metadata), and "all" (include all available
-#'  metadata). Default is "id".
+#'  data. Possible values are "id" (only include observation `insp_order`) and
+#'  "all" (include all available metadata). Default is "id".
 #'
 #' @return a tibble with the records from the selected inspection.
 #' @export
@@ -13,7 +12,7 @@
 #' @examples \dontrun{get_records("Vespa-Watch")}
 get_records <- function(inspection_name = "Vespa-Watch",
                         access_token = get_access_token(quiet = TRUE),
-                        get_metadata = c("id", "none", "all")) {
+                        get_metadata = c("id", "all")) {
   # check input params
   assertthat::assert_that(assertthat::is.string(access_token))
   assertthat::assert_that(assertthat::is.string(inspection_name))
@@ -54,11 +53,8 @@ get_records <- function(inspection_name = "Vespa-Watch",
           purrr::chuck(.x, "data")
         ))
       } else if (get_metadata == "all") {
-        # flatten the metadata and data to have every element on one level
+        # or flatten the metadata and data to have every elements on one level
         purrr::map(returndata, ~ purrr::list_flatten(.x, name_spec = "{inner}"))
-      } else if (get_metadata == "none") {
-        # or get the data object for every element
-        purrr::map(returndata, ~ purrr::chuck(.x, "data"))
       }
     }) %>%
     # flatten list contained in data

--- a/R/get_records.R
+++ b/R/get_records.R
@@ -38,8 +38,11 @@ get_records <- function(inspection_name = "Vespa-Watch",
     httr2::resp_body_json(records_response, check_type = FALSE) %>%
     ## convert into tibble
     purrr::chuck("returndata") %>%
-    # get the data object for every element
-    purrr::map(~purrr::chuck(.x, "data")) %>%
+    # get the metadata and data object for every element
+    purrr::map(~base::append(c("object_id" = .x$object_id,
+                               "inspection_id" = .x$inspection_id,
+                               "insp_order" = .x$insp_order),
+                purrr::chuck(.x, "data"))) %>%
     # flatten list
     purrr::map(~purrr::list_flatten(.x)) %>%
     # create a table per record

--- a/R/get_records.R
+++ b/R/get_records.R
@@ -2,8 +2,8 @@
 #'
 #' @param inspection_name name of the custom inspection to return records for
 #' @param access_token access token from `get_access_token()`
-#' @param get_metadata Indicates whether to include metadata in the returned data.
-#'  Possible values are "id" (only include observation `insp_order`),
+#' @param get_metadata Indicates whether to include metadata in the returned
+#'  data. Possible values are "id" (only include observation `insp_order`),
 #'  "none" (exclude all metadata), and "all" (include all available
 #'  metadata). Default is "id".
 #'
@@ -46,19 +46,19 @@ get_records <- function(inspection_name = "Vespa-Watch",
     ## convert into tibble
     purrr::chuck("returndata") %>%
     # based on get_metadata
-    (function (.){
+    (function(returndata) {
       if (get_metadata == "id") {
         # get the data with the id
-        purrr::map(., ~ base::append(
+        purrr::map(returndata, ~ base::append(
           c(insp_order = .x$insp_order),
           purrr::chuck(.x, "data")
         ))
       } else if (get_metadata == "all") {
         # flatten the metadata and data to have every element on one level
-        purrr::map(., ~ purrr::list_flatten(.x, name_spec = "{inner}"))
+        purrr::map(returndata, ~ purrr::list_flatten(.x, name_spec = "{inner}"))
       } else if (get_metadata == "none") {
         # or get the data object for every element
-        purrr::map(., ~ purrr::chuck(.x, "data"))
+        purrr::map(returndata, ~ purrr::chuck(.x, "data"))
       }
     }) %>%
     # flatten list contained in data

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,7 +3,8 @@
 #' To be used in across to recode values based on the `get_fields()` request
 #'
 #' @param field field to be recoded, tidyselect syntax
-#' @param field_name Character. Name of field to be recoded, within across `cur_column()`
+#' @param field_name Character. Name of field to be recoded, within across
+#' `cur_column()`
 #' @param inspection_fields named list, output of `get_fields()`
 #'
 #' @return function to be used by `dplyr::rename_with()`
@@ -15,9 +16,13 @@ recode_by_field <- function(field,
                               access_token = get_access_token(),
                               name = NULL # we expect inspection_fields to always be provided
                             )) {
-  dplyr::recode(field,
-                !!!dplyr::filter(inspection_fields$fields,
-                                 .data$id == field_name)$options)
+  dplyr::recode(
+    field,
+    !!!dplyr::filter(
+      inspection_fields$fields,
+      .data$id == field_name
+    )$options
+  )
 }
 
 #' Rename API columns with the label from `get_fields()`
@@ -25,8 +30,8 @@ recode_by_field <- function(field,
 #' During rectangling, a suffix might be added to the column name before
 #' renaming. This suffix is to be retained.
 #'
-#' If the provided `id` is not found in the inspection fields, the value of `id` is returned
-#' without modification. No error or warning is raised in this case.
+#' If the provided `id` is not found in the inspection fields, the value of `id`
+#' is returned without modification. No error or warning is raised in this case.
 #'
 #' @param id Column name as returned by the API.
 #' @param inspection_fields named list, output of `get_fields()`
@@ -39,18 +44,17 @@ rename_by_id <- function(id,
                            access_token = get_access_token(),
                            name = NULL # we expect inspection_fields to always be provided
                          )) {
-
   purrr::map_chr(id, function(id) {
     pure_id <- stringr::str_remove(id, "_[0-9]+")
     suffix <- stringr::str_extract(id, "_[0-9]+") %>%
       stringr::str_replace_na(replacement = "")
 
-    if (pure_id %in% inspection_fields$fields$id){
+    if (pure_id %in% inspection_fields$fields$id) {
       dplyr::filter(inspection_fields$fields, .data$id == pure_id) %>%
         dplyr::pull(.data$fieldlabel) %>%
         unique() %>%
         paste0(suffix)
-    }else{
+    } else {
       id
     }
   })

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,6 +25,9 @@ recode_by_field <- function(field,
 #' During rectangling, a suffix might be added to the column name before
 #' renaming. This suffix is to be retained.
 #'
+#' If the provided `id` is not found in the inspection fields, the value of `id` is returned
+#' without modification. No error or warning is raised in this case.
+#'
 #' @param id Column name as returned by the API.
 #' @param inspection_fields named list, output of `get_fields()`
 #'
@@ -42,9 +45,13 @@ rename_by_id <- function(id,
     suffix <- stringr::str_extract(id, "_[0-9]+") %>%
       stringr::str_replace_na(replacement = "")
 
-    dplyr::filter(inspection_fields$fields, .data$id == pure_id) %>%
-      dplyr::pull(.data$fieldlabel) %>%
-      unique() %>%
-      paste0(suffix)
+    if (pure_id %in% inspection_fields$fields$id){
+      dplyr::filter(inspection_fields$fields, .data$id == pure_id) %>%
+        dplyr::pull(.data$fieldlabel) %>%
+        unique() %>%
+        paste0(suffix)
+    }else{
+      id
+    }
   })
 }

--- a/man/get_records.Rd
+++ b/man/get_records.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/get_records.R
 \name{get_records}
 \alias{get_records}
-\title{Title}
+\title{Get all records in a custom inspection}
 \usage{
 get_records(
   inspection_name = "Vespa-Watch",
   access_token = get_access_token(quiet = TRUE),
-  get_metadata = FALSE
+  get_metadata = c("id", "none", "all")
 )
 }
 \arguments{
@@ -15,13 +15,16 @@ get_records(
 
 \item{access_token}{access token from \code{get_access_token()}}
 
-\item{get_metadata}{Should the function return the meta data of all observations}
+\item{get_metadata}{Indicates whether to include metadata in the returned data.
+Possible values are "id" (only include observation \code{insp_order}),
+"none" (exclude all metadata), and "all" (include all available
+metadata). Default is "id".}
 }
 \value{
 a tibble with the records from the selected inspection.
 }
 \description{
-Title
+Get all records in a custom inspection
 }
 \examples{
 \dontrun{get_records("Vespa-Watch")}

--- a/man/get_records.Rd
+++ b/man/get_records.Rd
@@ -6,13 +6,16 @@
 \usage{
 get_records(
   inspection_name = "Vespa-Watch",
-  access_token = get_access_token(quiet = TRUE)
+  access_token = get_access_token(quiet = TRUE),
+  get_metadata = FALSE
 )
 }
 \arguments{
 \item{inspection_name}{name of the custom inspection to return records for}
 
 \item{access_token}{access token from \code{get_access_token()}}
+
+\item{get_metadata}{Should the function return the meta data of all observations}
 }
 \value{
 a tibble with the records from the selected inspection.

--- a/man/get_records.Rd
+++ b/man/get_records.Rd
@@ -7,7 +7,7 @@
 get_records(
   inspection_name = "Vespa-Watch",
   access_token = get_access_token(quiet = TRUE),
-  get_metadata = c("id", "none", "all")
+  get_metadata = c("id", "all")
 )
 }
 \arguments{
@@ -16,9 +16,8 @@ get_records(
 \item{access_token}{access token from \code{get_access_token()}}
 
 \item{get_metadata}{Indicates whether to include metadata in the returned
-data. Possible values are "id" (only include observation \code{insp_order}),
-"none" (exclude all metadata), and "all" (include all available
-metadata). Default is "id".}
+data. Possible values are "id" (only include observation \code{insp_order}) and
+"all" (include all available metadata). Default is "id".}
 }
 \value{
 a tibble with the records from the selected inspection.

--- a/man/get_records.Rd
+++ b/man/get_records.Rd
@@ -15,8 +15,8 @@ get_records(
 
 \item{access_token}{access token from \code{get_access_token()}}
 
-\item{get_metadata}{Indicates whether to include metadata in the returned data.
-Possible values are "id" (only include observation \code{insp_order}),
+\item{get_metadata}{Indicates whether to include metadata in the returned
+data. Possible values are "id" (only include observation \code{insp_order}),
 "none" (exclude all metadata), and "all" (include all available
 metadata). Default is "id".}
 }

--- a/man/iassetR-package.Rd
+++ b/man/iassetR-package.Rd
@@ -8,6 +8,13 @@
 \description{
 This package is an interface to the REST api of iAsset.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://inbo.github.io/iassetR/}
+}
+
+}
 \author{
 \strong{Maintainer}: Pieter Huybrechts \email{pieter.huybrechts@inbo.be} (\href{https://orcid.org/0000-0002-6658-6062}{ORCID})
 


### PR DESCRIPTION
Fixes #31.

# List of changes
- All the metadata can be saved by `get_records()`.
- A get_metadata argument has been added to `get_records()`. Possible values are `id` (only include `insp_order`), and `all` (include all available metadata). Default is `id`.
- The `rename_by_id()` has been modified to accept field IDs not present in `inspection_fields`.

# A possible improvement I currently see 
- Currently, when using `get_record(get_metadata="all")`, it's difficult to tell apart metadata and data columns. Saving metadata in a totally different way could be the way to go, but I don't know how it could be clear and efficient at the same time.