### PR TITLE
Switch to artifacts v4

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
> Starting December 5, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible. While v4 of the artifact actions improves upload and download speeds by up to 98% and includes several new features, there are [key differences](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) from previous versions that may require updates to your workflows. Please see [the documentation](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) in the project repositories for guidance on how to migrate your workflows.

Closes #45 

